### PR TITLE
Serialize feature flags before importing

### DIFF
--- a/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
@@ -5,7 +5,6 @@ import {
   SetConfigurationSettingParam,
   featureFlagPrefix,
   featureFlagContentType,
-  ConfigurationSettingParam,
   SecretReferenceValue
 } from "@azure/app-configuration";
 import { SourceOptions } from "../../importOptions";
@@ -40,7 +39,7 @@ export class DefaultConfigurationSettingsConverter implements ConfigurationSetti
       SetConfigurationSettingParam<string | MsFeatureFlagValue>
     >();
 
-    let featureFlagsConfigSettings = new Array<ConfigurationSettingParam>();
+    let featureFlagsConfigSettings = new Array<SetConfigurationSettingParam<string>>();
     let foundMsFmSchema = false;
     let foundDotnetFmSchema = false;
     let dotnetFmSchemaKeyWord = "";
@@ -188,8 +187,8 @@ class FeatureFlagConfigurationSettingsConverter implements ConfigurationSettings
   Convert(
     config: object,
     options: SourceOptions
-  ): ConfigurationSettingParam[] {
-    const settings = new Array<ConfigurationSettingParam>();
+  ): SetConfigurationSettingParam<string>[] {
+    const settings = new Array<SetConfigurationSettingParam<string>>();
     const featureFlags = new Array<MsFeatureFlagValue>();
 
     if (this.dotnetFmSchemaKeyWord) {
@@ -256,8 +255,7 @@ class FeatureFlagConfigurationSettingsConverter implements ConfigurationSettings
         tags: options.tags
       };
 
-      const serializedSetting: ConfigurationSettingParam = serializeFeatureFlagToConfigurationSettingParam(setting);
-
+      const serializedSetting: SetConfigurationSettingParam<string> = serializeFeatureFlagToConfigurationSettingParam(setting);
       settings.push(serializedSetting);
     }
 

--- a/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
@@ -3,9 +3,10 @@
 
 import {
   SetConfigurationSettingParam,
-  SecretReferenceValue,
   featureFlagPrefix,
-  featureFlagContentType
+  featureFlagContentType,
+  ConfigurationSettingParam,
+  SecretReferenceValue
 } from "@azure/app-configuration";
 import { SourceOptions } from "../../importOptions";
 import { ConfigurationSettingsConverter } from "./configurationSettingsConverter";
@@ -13,7 +14,7 @@ import { AjvValidationError, ArgumentError } from "../../errors";
 import { ClientFilter } from "../../models";
 import * as flat from "flat";
 import { ConfigurationFormat } from "../../enums";
-import { isJsonContentType } from "../utils";
+import { isJsonContentType, serializeFeatureFlagToConfigurationSettingParam } from "../utils";
 import { MsFeatureFlagValue, RequirementType } from "../../featureFlag";
 import { Constants } from "../constants";
 import { MsFeatureFlagValueSchema } from "../../MsFeatureFlagSchema";
@@ -39,7 +40,7 @@ export class DefaultConfigurationSettingsConverter implements ConfigurationSetti
       SetConfigurationSettingParam<string | MsFeatureFlagValue>
     >();
 
-    let featureFlagsConfigSettings = new Array<SetConfigurationSettingParam<MsFeatureFlagValue>>();
+    let featureFlagsConfigSettings = new Array<ConfigurationSettingParam>();
     let foundMsFmSchema = false;
     let foundDotnetFmSchema = false;
     let dotnetFmSchemaKeyWord = "";
@@ -187,8 +188,8 @@ class FeatureFlagConfigurationSettingsConverter implements ConfigurationSettings
   Convert(
     config: object,
     options: SourceOptions
-  ): SetConfigurationSettingParam<MsFeatureFlagValue>[] {
-    const settings = new Array<SetConfigurationSettingParam<MsFeatureFlagValue>>();
+  ): ConfigurationSettingParam[] {
+    const settings = new Array<ConfigurationSettingParam>();
     const featureFlags = new Array<MsFeatureFlagValue>();
 
     if (this.dotnetFmSchemaKeyWord) {
@@ -255,7 +256,9 @@ class FeatureFlagConfigurationSettingsConverter implements ConfigurationSettings
         tags: options.tags
       };
 
-      settings.push(setting);
+      const serializedSetting: ConfigurationSettingParam = serializeFeatureFlagToConfigurationSettingParam(setting);
+
+      settings.push(serializedSetting);
     }
 
     return settings;

--- a/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
@@ -13,7 +13,7 @@ import { AjvValidationError, ArgumentError } from "../../errors";
 import { ClientFilter } from "../../models";
 import * as flat from "flat";
 import { ConfigurationFormat } from "../../enums";
-import { isJsonContentType, serializeFeatureFlagToConfigurationSettingParam } from "../utils";
+import { isJsonContentType, serializeFeatureFlagValue } from "../utils";
 import { MsFeatureFlagValue, RequirementType } from "../../featureFlag";
 import { Constants } from "../constants";
 import { MsFeatureFlagValueSchema } from "../../MsFeatureFlagSchema";
@@ -247,16 +247,15 @@ class FeatureFlagConfigurationSettingsConverter implements ConfigurationSettings
 
     const prefix: string = options.prefix ?? "";
     for (const featureFlag of featureFlags) {
-      const setting: SetConfigurationSettingParam<MsFeatureFlagValue> = {
+      const setting: SetConfigurationSettingParam<string> = {
         key: featureFlagPrefix + prefix + featureFlag.id,
         label: options.label,
-        value: featureFlag,
+        value: serializeFeatureFlagValue(featureFlag),
         contentType: featureFlagContentType,
         tags: options.tags
       };
 
-      const serializedSetting: SetConfigurationSettingParam<string> = serializeFeatureFlagToConfigurationSettingParam(setting);
-      settings.push(serializedSetting);
+      settings.push(setting);
     }
 
     return settings;

--- a/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/parsers/defaultConfigurationSettingsConverter.ts
@@ -34,9 +34,9 @@ export class DefaultConfigurationSettingsConverter implements ConfigurationSetti
   public Convert(
     config: object,
     options: SourceOptions
-  ): SetConfigurationSettingParam<string | MsFeatureFlagValue | SecretReferenceValue>[] {
+  ): SetConfigurationSettingParam<string | SecretReferenceValue>[] {
     let configurationSettings = new Array<
-      SetConfigurationSettingParam<string | MsFeatureFlagValue>
+      SetConfigurationSettingParam<string>
     >();
 
     let featureFlagsConfigSettings = new Array<SetConfigurationSettingParam<string>>();

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -173,7 +173,7 @@ function toFeatureFlagValue(value: string): FeatureFlagValue {
 
 export function serializeFeatureFlagValue(featureFlagValue: MsFeatureFlagValue): string {
   if (!featureFlagValue) {
-    throw new TypeError(`Invalid feature flag value - ${featureFlagValue}`);
+    throw new TypeError("Invalid feature flag value");
   }
 
   const jsonFeatureFlagValue: any = {

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -172,35 +172,24 @@ function toFeatureFlagValue(value: string): FeatureFlagValue {
   };
 }
 
-export function serializeFeatureFlagToConfigurationSettingParam(featureFlag: SetConfigurationSettingParam<MsFeatureFlagValue>): SetConfigurationSettingParam<string> {
-  if (!featureFlag.value) {
-    throw new TypeError(`FeatureFlag has an unexpected value - ${featureFlag.value}`);
-  }
-
-  let key = featureFlag.key;
-
-  if (typeof featureFlag.key === "string" && !featureFlag.key.startsWith(featureFlagPrefix)) {
-    key = featureFlagPrefix + featureFlag.key;
+export function serializeFeatureFlagValue(featureFlagValue: MsFeatureFlagValue): string {
+  if (!featureFlagValue) {
+    throw new TypeError(`FeatureFlag has an unexpected value - ${featureFlagValue}`);
   }
 
   const jsonFeatureFlagValue: JsonFeatureFlagValue = {
-    id: featureFlag.value.id ?? key.replace(featureFlagPrefix, ""),
-    enabled: featureFlag.value.enabled,
-    description: featureFlag.value.description,
+    id: featureFlagValue.id,
+    enabled: featureFlagValue.enabled,
+    description: featureFlagValue.description,
     conditions: {
-      client_filters: featureFlag.value.conditions?.clientFilters
+      client_filters: featureFlagValue.conditions?.clientFilters,
+      requirement_type: featureFlagValue.conditions?.requirementType
     },
-    display_name: featureFlag.value.displayName,
-    allocation: featureFlag.value.allocation,
-    variants: featureFlag.value.variants,
-    telemetry: featureFlag.value.telemetry
+    display_name: featureFlagValue.displayName,
+    allocation: featureFlagValue.allocation,
+    variants: featureFlagValue.variants,
+    telemetry: featureFlagValue.telemetry
   };
 
-  const configSetting: SetConfigurationSettingParam<string> = {
-    ...featureFlag,
-    key,
-    value: JSON.stringify(jsonFeatureFlagValue)
-  };
-
-  return configSetting;
+  return JSON.stringify(jsonFeatureFlagValue);
 }

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -173,7 +173,7 @@ function toFeatureFlagValue(value: string): FeatureFlagValue {
 
 export function serializeFeatureFlagValue(featureFlagValue: MsFeatureFlagValue): string {
   if (!featureFlagValue) {
-    throw new TypeError(`FeatureFlag has an unexpected value - ${featureFlagValue}`);
+    throw new TypeError(`Invalid feature flag value - ${featureFlagValue}`);
   }
 
   const jsonFeatureFlagValue: any = {

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -176,6 +176,7 @@ export function serializeFeatureFlagToConfigurationSettingParam(featureFlag: Set
   if (!featureFlag.value) {
     throw new TypeError(`FeatureFlag has an unexpected value - ${featureFlag.value}`);
   }
+
   let key = featureFlag.key;
 
   if (typeof featureFlag.key === "string" && !featureFlag.key.startsWith(featureFlagPrefix)) {
@@ -195,10 +196,11 @@ export function serializeFeatureFlagToConfigurationSettingParam(featureFlag: Set
     telemetry: featureFlag.value.telemetry
   };
 
-  const configSetting = {
+  const configSetting: SetConfigurationSettingParam<string> = {
     ...featureFlag,
     key,
     value: JSON.stringify(jsonFeatureFlagValue)
   };
+
   return configSetting;
 }

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -6,8 +6,7 @@ import {
   SetConfigurationSettingParam, 
   FeatureFlagValue,
   featureFlagContentType,
-  SecretReferenceValue,
-  featureFlagPrefix } from "@azure/app-configuration";
+  SecretReferenceValue } from "@azure/app-configuration";
 import { isEmpty, isEqual } from "lodash";
 import { Tags, FeatureFlagClientFilters, JsonFeatureFlagValue } from "../models";
 import { SourceOptions } from "../importOptions";

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -8,7 +8,7 @@ import {
   featureFlagContentType,
   SecretReferenceValue } from "@azure/app-configuration";
 import { isEmpty, isEqual } from "lodash";
-import { Tags, FeatureFlagClientFilters, JsonFeatureFlagValue } from "../models";
+import { Tags, FeatureFlagClientFilters } from "../models";
 import { SourceOptions } from "../importOptions";
 import { ConfigurationFormat, ConfigurationProfile } from "../enums";
 import { ArgumentError, ArgumentNullError } from "../errors";
@@ -176,19 +176,31 @@ export function serializeFeatureFlagValue(featureFlagValue: MsFeatureFlagValue):
     throw new TypeError(`FeatureFlag has an unexpected value - ${featureFlagValue}`);
   }
 
-  const jsonFeatureFlagValue: JsonFeatureFlagValue = {
+  const jsonFeatureFlagValue: any = {
     id: featureFlagValue.id,
     enabled: featureFlagValue.enabled,
     description: featureFlagValue.description,
     conditions: {
-      client_filters: featureFlagValue.conditions?.clientFilters,
-      requirement_type: featureFlagValue.conditions?.requirementType
+      client_filters: featureFlagValue.conditions?.clientFilters
     },
-    display_name: featureFlagValue.displayName,
-    allocation: featureFlagValue.allocation,
-    variants: featureFlagValue.variants,
-    telemetry: featureFlagValue.telemetry
+    display_name: featureFlagValue.displayName
   };
+
+  if (featureFlagValue.conditions && featureFlagValue.conditions.requirementType) {
+    jsonFeatureFlagValue.conditions.requirement_type = featureFlagValue.conditions.requirementType;
+  }
+
+  if (featureFlagValue.allocation) {
+    jsonFeatureFlagValue.allocation = featureFlagValue.allocation;
+  }
+
+  if (featureFlagValue.variants) {
+    jsonFeatureFlagValue.variants = featureFlagValue.variants;
+  }
+
+  if (featureFlagValue.telemetry) {
+    jsonFeatureFlagValue.telemetry = featureFlagValue.telemetry;
+  }
 
   return JSON.stringify(jsonFeatureFlagValue);
 }

--- a/libraries/azure-app-configuration-importer/src/internal/utils.ts
+++ b/libraries/azure-app-configuration-importer/src/internal/utils.ts
@@ -6,11 +6,10 @@ import {
   SetConfigurationSettingParam, 
   FeatureFlagValue,
   featureFlagContentType,
-  SecretReferenceValue, 
-  ConfigurationSettingParam,
-  featureFlagPrefix} from "@azure/app-configuration";
+  SecretReferenceValue,
+  featureFlagPrefix } from "@azure/app-configuration";
 import { isEmpty, isEqual } from "lodash";
-import { Tags, FeatureFlagClientFilters } from "../models";
+import { Tags, FeatureFlagClientFilters, JsonFeatureFlagValue } from "../models";
 import { SourceOptions } from "../importOptions";
 import { ConfigurationFormat, ConfigurationProfile } from "../enums";
 import { ArgumentError, ArgumentNullError } from "../errors";
@@ -173,22 +172,24 @@ function toFeatureFlagValue(value: string): FeatureFlagValue {
   };
 }
 
-export function serializeFeatureFlagToConfigurationSettingParam(featureFlag: SetConfigurationSettingParam<MsFeatureFlagValue>): ConfigurationSettingParam {
+export function serializeFeatureFlagToConfigurationSettingParam(featureFlag: SetConfigurationSettingParam<MsFeatureFlagValue>): SetConfigurationSettingParam<string> {
   if (!featureFlag.value) {
     throw new TypeError(`FeatureFlag has an unexpected value - ${featureFlag.value}`);
   }
   let key = featureFlag.key;
+
   if (typeof featureFlag.key === "string" && !featureFlag.key.startsWith(featureFlagPrefix)) {
     key = featureFlagPrefix + featureFlag.key;
   }
-  const jsonFeatureFlagValue: MsFeatureFlagValue = {
+
+  const jsonFeatureFlagValue: JsonFeatureFlagValue = {
     id: featureFlag.value.id ?? key.replace(featureFlagPrefix, ""),
     enabled: featureFlag.value.enabled,
     description: featureFlag.value.description,
     conditions: {
-      clientFilters: featureFlag.value.conditions?.clientFilters
+      client_filters: featureFlag.value.conditions?.clientFilters
     },
-    displayName: featureFlag.value.displayName,
+    display_name: featureFlag.value.displayName,
     allocation: featureFlag.value.allocation,
     variants: featureFlag.value.variants,
     telemetry: featureFlag.value.telemetry

--- a/libraries/azure-app-configuration-importer/src/models.ts
+++ b/libraries/azure-app-configuration-importer/src/models.ts
@@ -16,30 +16,6 @@ export interface JsonSecretReferenceValue {
 /**
  * @internal
  */
-export type JsonFeatureFlagValue = {
-  conditions: {
-    client_filters: { name: string; parameters?: Record<string, unknown> }[];
-    requirement_type?: string;
-  };
-  enabled: boolean;
-  description?: string;
-  id?: string;
-  display_name?: string;
-  allocation?: {
-    user?: { variant: string; users: string[] }[];
-    group?: { variant: string; groups: string[] }[];
-    default_when_enabled?: string;
-    default_when_disabled?: string;
-    percentile?: { variant: string; from: number; to: number }[];
-    seed?: string;
-  };
-  variants?: { name: string; configuration_value?: string | number | object | boolean; status_override?: string }[];
-  telemetry?: { enabled?: boolean; metadata?: object };
-};
-
-/**
- * @internal
- */
 export type KvSetConfigurationItem = {
   key: string;
   value?: string;

--- a/libraries/azure-app-configuration-importer/src/models.ts
+++ b/libraries/azure-app-configuration-importer/src/models.ts
@@ -20,8 +20,8 @@ export type JsonFeatureFlagValue = {
   conditions: {
     client_filters: { name: string; parameters?: Record<string, unknown> }[];
   };
-  description?: string;
   enabled: boolean;
+  description?: string;
   id?: string;
   display_name?: string;
   allocation?: {

--- a/libraries/azure-app-configuration-importer/src/models.ts
+++ b/libraries/azure-app-configuration-importer/src/models.ts
@@ -19,6 +19,7 @@ export interface JsonSecretReferenceValue {
 export type JsonFeatureFlagValue = {
   conditions: {
     client_filters: { name: string; parameters?: Record<string, unknown> }[];
+    requirement_type?: string;
   };
   enabled: boolean;
   description?: string;

--- a/libraries/azure-app-configuration-importer/src/models.ts
+++ b/libraries/azure-app-configuration-importer/src/models.ts
@@ -16,6 +16,29 @@ export interface JsonSecretReferenceValue {
 /**
  * @internal
  */
+export type JsonFeatureFlagValue = {
+  conditions: {
+    client_filters: { name: string; parameters?: Record<string, unknown> }[];
+  };
+  description?: string;
+  enabled: boolean;
+  id?: string;
+  display_name?: string;
+  allocation?: {
+    user?: { variant: string; users: string[] }[];
+    group?: { variant: string; groups: string[] }[];
+    default_when_enabled?: string;
+    default_when_disabled?: string;
+    percentile?: { variant: string; from: number; to: number }[];
+    seed?: string;
+  };
+  variants?: { name: string; configuration_value?: string | number | object | boolean; status_override?: string }[];
+  telemetry?: { enabled?: boolean; metadata?: object };
+};
+
+/**
+ * @internal
+ */
 export type KvSetConfigurationItem = {
   key: string;
   value?: string;

--- a/libraries/azure-app-configuration-importer/tests/featureFlagConfigurationSettingsConverter.spec.ts
+++ b/libraries/azure-app-configuration-importer/tests/featureFlagConfigurationSettingsConverter.spec.ts
@@ -65,32 +65,32 @@ describe("Parse FeatureFlag Json format file", () => {
       "{\"Settings\":{\"BackgroundColor\":\"Yellow\",\"FontSize\":\"45\",\"Fruit\":\"Banana\",\"Color\":\"Orange\",\"FontColor\":\"Black\"}}"
     );
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}${options.prefix}FeatureT`);
-    const featureFlag1 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureT");
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}${options.prefix}FeatureU`);
-    const featureFlag2 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureU");
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[3].key, `${featureFlagPrefix}${options.prefix}FeatureV`);
-    const featureFlag3 = configurationSettings[3].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[3].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureV");
     assert.equal(
       JSON.stringify(featureFlag3.conditions),
-      "{\"clientFilters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.isTrue(featureFlag3.enabled);
     assert.equal(configurationSettings[4].key, `${featureFlagPrefix}${options.prefix}FeatureX`);
-    const featureFlag4 = configurationSettings[4].value as MsFeatureFlagValue;
+    const featureFlag4 = JSON.parse(configurationSettings[4].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag4.id, "FeatureX");
-    assert.equal(JSON.stringify(featureFlag4.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag4.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag4.enabled);
     assert.equal(configurationSettings[5].key, `${featureFlagPrefix}${options.prefix}FeatureY`);
-    const featureFlag5 = configurationSettings[5].value as MsFeatureFlagValue;
+    const featureFlag5 = JSON.parse(configurationSettings[5].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag5.id, "FeatureY");
-    assert.equal(JSON.stringify(featureFlag5.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag5.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag5.enabled);
   });
 
@@ -127,32 +127,32 @@ describe("Parse FeatureFlag Json format file", () => {
       "{\"Settings\":{\"BackgroundColor\":\"Yellow\",\"FontSize\":\"45\",\"Fruit\":\"Banana\",\"Color\":\"Orange\",\"FontColor\":\"Black\"}}"
     );
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureT`);
-    const featureFlag1 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureT");
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureU`);
-    const featureFlag2 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureU");
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[3].key, `${featureFlagPrefix}FeatureV`);
-    const featureFlag3 = configurationSettings[3].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[3].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureV");
     assert.equal(
       JSON.stringify(featureFlag3.conditions),
-      "{\"clientFilters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.isTrue(featureFlag3.enabled);
     assert.equal(configurationSettings[4].key, `${featureFlagPrefix}FeatureX`);
-    const featureFlag4 = configurationSettings[4].value as MsFeatureFlagValue;
+    const featureFlag4 = JSON.parse(configurationSettings[4].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag4.id, "FeatureX");
-    assert.equal(JSON.stringify(featureFlag4.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag4.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag4.enabled);
     assert.equal(configurationSettings[5].key, `${featureFlagPrefix}FeatureY`);
-    const featureFlag5 = configurationSettings[5].value as MsFeatureFlagValue;
+    const featureFlag5 = JSON.parse(configurationSettings[5].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag5.id, "FeatureY");
-    assert.equal(JSON.stringify(featureFlag5.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag5.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag5.enabled);
   });
 
@@ -184,44 +184,44 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings[1].label, "testLabel");
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
     assert.equal(configurationSettings[1].tags, testTag);
-    const featureFlag1 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureT");
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureU`);
     assert.equal(configurationSettings[2].label, "testLabel");
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
     assert.equal(configurationSettings[2].tags, testTag);
-    const featureFlag2 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureU");
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[3].key, `${featureFlagPrefix}FeatureV`);
     assert.equal(configurationSettings[3].label, "testLabel");
     assert.equal(configurationSettings[3].contentType, featureFlagContentType);
     assert.equal(configurationSettings[3].tags, testTag);
-    const featureFlag3 = configurationSettings[3].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[3].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureV");
     assert.equal(
       JSON.stringify(featureFlag3.conditions),
-      "{\"clientFilters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.isTrue(featureFlag3.enabled);
     assert.equal(configurationSettings[4].key, `${featureFlagPrefix}FeatureX`);
     assert.equal(configurationSettings[4].label, "testLabel");
     assert.equal(configurationSettings[4].contentType, featureFlagContentType);
     assert.equal(configurationSettings[4].tags, testTag);
-    const featureFlag4 = configurationSettings[4].value as MsFeatureFlagValue;
+    const featureFlag4 = JSON.parse(configurationSettings[4].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag4.id, "FeatureX");
-    assert.equal(JSON.stringify(featureFlag4.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag4.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag4.enabled);
     assert.equal(configurationSettings[5].key, `${featureFlagPrefix}FeatureY`);
     assert.equal(configurationSettings[5].label, "testLabel");
     assert.equal(configurationSettings[5].contentType, featureFlagContentType);
     assert.equal(configurationSettings[5].tags, testTag);
-    const featureFlag5 = configurationSettings[5].value as MsFeatureFlagValue;
+    const featureFlag5 = JSON.parse(configurationSettings[5].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag5.id, "FeatureY");
-    assert.equal(JSON.stringify(featureFlag5.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag5.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag5.enabled);
   });
 
@@ -309,23 +309,23 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}FeatureT`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureT");
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureU`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureU");
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureV`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureV");
     assert.equal(
       JSON.stringify(featureFlag3.conditions),
-      "{\"clientFilters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"end\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"end\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.isTrue(featureFlag3.enabled);
   });
@@ -341,18 +341,18 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}Variant_Override_True`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "Variant_Override_True");
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.equal(JSON.stringify(featureFlag1.allocation), "{\"default_when_enabled\":\"True_Override\"}");
     assert.equal(JSON.stringify(featureFlag1.variants),
       "[{\"name\":\"True_Override\",\"status_override\":\"Disabled\",\"configuration_value\":\"default\"}]");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}Variant_Override_False`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "Variant_Override_False");
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.equal(JSON.stringify(featureFlag2.allocation), "{\"default_when_disabled\":\"False_Override\"}");
     assert.equal(JSON.stringify(featureFlag2.variants),
       "[{\"name\":\"False_Override\",\"status_override\":\"Enabled\",\"configuration_value\":\"default\"}]");
@@ -360,11 +360,11 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}TestVariants`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "TestVariants");
     assert.equal(
       JSON.stringify(featureFlag3.conditions),
-      "{\"clientFilters\":[{\"Name\":\"TimeWindow\",\"Parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"Name\":\"TimeWindow\",\"Parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.equal(JSON.stringify(featureFlag3.allocation),"{\"user\":[{\"variant\":\"Alpha\",\"users\":[\"Adam\"]},{\"variant\":\"Beta\",\"users\":[\"Britney\"]}]}");
     assert.equal(JSON.stringify(featureFlag3.variants),
@@ -383,18 +383,18 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}Variant_Override_True`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "Variant_Override_True");
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.equal(JSON.stringify(featureFlag1.allocation), "{\"default_when_enabled\":\"True_Override\"}");
     assert.equal(JSON.stringify(featureFlag1.variants),
       "[{\"name\":\"True_Override\",\"status_override\":\"Disabled\",\"configuration_value\":\"default\"}]");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}Variant_Override_False`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "Variant_Override_False");
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.equal(JSON.stringify(featureFlag2.allocation), "{\"default_when_disabled\":\"False_Override\"}");
     assert.equal(JSON.stringify(featureFlag2.variants),
       "[{\"name\":\"False_Override\",\"status_override\":\"Enabled\",\"configuration_value\":\"default\"}]");
@@ -402,11 +402,11 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}TestVariants`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "TestVariants");
     assert.equal(
       JSON.stringify(featureFlag3.conditions),
-      "{\"clientFilters\":[{\"Name\":\"TimeWindow\",\"Parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"Name\":\"TimeWindow\",\"Parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.equal(JSON.stringify(featureFlag3.allocation),"{\"user\":[{\"variant\":\"Alpha\",\"users\":[\"Adam\"]},{\"variant\":\"Beta\",\"users\":[\"Britney\"]}]}");
     assert.equal(JSON.stringify(featureFlag3.variants),
@@ -471,22 +471,22 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}FeatureX`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureX");
     assert.isTrue(featureFlag1.enabled);
-    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag1.conditions), "{\"client_filters\":[]}");
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureY`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureY");
     assert.isFalse(featureFlag2.enabled);
-    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag2.conditions), "{\"client_filters\":[]}");
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureZ`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureZ");
     assert.isTrue(featureFlag3.enabled);
-    assert.equal(JSON.stringify(featureFlag3.conditions), "{\"clientFilters\":[]}");
+    assert.equal(JSON.stringify(featureFlag3.conditions), "{\"client_filters\":[]}");
   });
 
   it("Respect both feature management schemas, FeatureManagement + feature_management in the same file", async () => {
@@ -502,17 +502,17 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}FeatureX`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureX");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureY`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureY");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureZ`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureZ");
     assert.isTrue(featureFlag3.enabled);
   });
@@ -542,17 +542,17 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}FeatureX`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureX");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureY`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureY");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureZ`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureZ");
     assert.isTrue(featureFlag3.enabled);
   });
@@ -570,21 +570,21 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 3);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}FeatureX`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureX");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(
       JSON.stringify(featureFlag1.conditions),
-      "{\"clientFilters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
+      "{\"client_filters\":[{\"name\":\"TimeWindow\",\"parameters\":{\"Start\":\"Wed, 01 May 2019 13:59:59 GMT\",\"End\":\"Mon, 01 July 2019 00:00:00 GMT\"}}]}"
     );
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureY`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureY");
     assert.isFalse(featureFlag2.enabled);
     assert.equal(configurationSettings[2].key, `${featureFlagPrefix}FeatureZ`);
     assert.equal(configurationSettings[2].contentType, featureFlagContentType);
-    const featureFlag3 = configurationSettings[2].value as MsFeatureFlagValue;
+    const featureFlag3 = JSON.parse(configurationSettings[2].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag3.id, "FeatureZ");
     assert.isTrue(featureFlag3.enabled);
   });
@@ -613,12 +613,12 @@ describe("Parse FeatureFlag Json format file", () => {
     assert.equal(configurationSettings.length, 2);
     assert.equal(configurationSettings[0].key, `${featureFlagPrefix}FeatureA`);
     assert.equal(configurationSettings[0].contentType, featureFlagContentType);
-    const featureFlag1 = configurationSettings[0].value as MsFeatureFlagValue;
+    const featureFlag1 = JSON.parse(configurationSettings[0].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag1.id, "FeatureA");
     assert.isTrue(featureFlag1.enabled);
     assert.equal(configurationSettings[1].key, `${featureFlagPrefix}FeatureZ`);
     assert.equal(configurationSettings[1].contentType, featureFlagContentType);
-    const featureFlag2 = configurationSettings[1].value as MsFeatureFlagValue;
+    const featureFlag2 = JSON.parse(configurationSettings[1].value as string) as MsFeatureFlagValue;
     assert.equal(featureFlag2.id, "FeatureZ");
     assert.isFalse(featureFlag2.enabled);
   });


### PR DESCRIPTION
This is a workaround since when importing variant feature flag with the current sdk the variant properties are dropped by the sdk here when it tries to serialize the feature flag here -https://github.com/Azure/azure-sdk-for-js/blob/87f78037cf2e562cba511e8699147b937c4a9ac7/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts#L233