### PR TITLE
Improve performance of GetConfigurationChanges (parallel fetch + O(N+M) lookup)

### DIFF
--- a/libraries/azure-app-configuration-importer-file-source/package.json
+++ b/libraries/azure-app-configuration-importer-file-source/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration-importer-file-source",
   "author": "Microsoft Corporation",
   "description": "A client library for importing/exporting key-values between configuration file sources and Azure App Configuration service",
-  "version": "3.0.0-preview",
+  "version": "3.0.0-preview.2",
   "sdk-type": "client",
   "keywords": [
     "node",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@azure/app-configuration": "^1.9.0",
-    "@azure/app-configuration-importer": "3.0.0-preview"
+    "@azure/app-configuration-importer": "3.0.0-preview.2"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.22.2",

--- a/libraries/azure-app-configuration-importer-file-source/package.json
+++ b/libraries/azure-app-configuration-importer-file-source/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration-importer-file-source",
   "author": "Microsoft Corporation",
   "description": "A client library for importing/exporting key-values between configuration file sources and Azure App Configuration service",
-  "version": "3.0.0-preview.2",
+  "version": "3.0.1-preview",
   "sdk-type": "client",
   "keywords": [
     "node",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@azure/app-configuration": "^1.9.0",
-    "@azure/app-configuration-importer": "3.0.0-preview.2"
+    "@azure/app-configuration-importer": "3.0.1-preview"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.22.2",

--- a/libraries/azure-app-configuration-importer/package.json
+++ b/libraries/azure-app-configuration-importer/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration-importer",
   "author": "Microsoft Corporation",
   "description": "A client library for importing/exporting key-values between configuration sources and Azure App Configuration service",
-  "version": "3.0.0-preview",
+  "version": "3.0.0-preview.2",
   "sdk-type": "client",
   "keywords": [
     "node",

--- a/libraries/azure-app-configuration-importer/package.json
+++ b/libraries/azure-app-configuration-importer/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration-importer",
   "author": "Microsoft Corporation",
   "description": "A client library for importing/exporting key-values between configuration sources and Azure App Configuration service",
-  "version": "3.0.0-preview.2",
+  "version": "3.0.1-preview",
   "sdk-type": "client",
   "keywords": [
     "node",

--- a/libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts
+++ b/libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts
@@ -12,7 +12,7 @@ import { ConfigurationChangesSource } from "./settingsImport/configurationChange
 import { ImportMode, ChangeType } from "./enums";
 import { OperationTimeoutError, ArgumentError } from "./errors";
 import { AdaptiveTaskManager } from "./internal/adaptiveTaskManager";
-import { ImportProgress, KeyLabelLookup, ConfigurationSettingChange } from "./models";
+import { ImportProgress, ConfigurationSettingChange } from "./models";
 import { isConfigSettingEqual } from "./internal/utils";
 import { v4 as uuidv4 } from "uuid";
 import { Constants } from "./internal/constants";
@@ -121,7 +121,22 @@ export class AppConfigurationImporter {
       };
     }
 
-    const configSettingsResult = await configSettingsSource.GetConfigurationSettings();
+    // Fetch source settings and target store settings in parallel.
+    // For ConfigurationChangesSource the target listing is skipped (changes are pre-calculated and
+    // FilterOptions are not supported on that source type).
+    const isChangesSource = configSettingsSource instanceof ConfigurationChangesSource;
+    const sourcePromise = configSettingsSource.GetConfigurationSettings();
+    const targetPromise: Promise<ConfigurationSetting[]> = isChangesSource
+      ? Promise.resolve([])
+      : (async () => {
+        const items: ConfigurationSetting[] = [];
+        for await (const existing of this.configurationClient.listConfigurationSettings({...configSettingsSource.FilterOptions, ...customHeadersOption})) {
+          items.push(existing);
+        }
+        return items;
+      })();
+
+    const configSettingsResult = await sourcePromise;
 
     // If the source returns ConfigurationChanges (e.g., ConfigurationChangesSource), 
     // return them directly without further processing since changes are already calculated
@@ -131,21 +146,22 @@ export class AppConfigurationImporter {
   
     const configSettings = configSettingsResult as Array<SetConfigurationSettingParam<string | FeatureFlagValue | SecretReferenceValue>>;
     const configurationChanges: Array<ConfigurationSettingChange> = [];
-    const configurationSettingToAdd: SetConfigurationSettingParam<string | FeatureFlagValue | SecretReferenceValue>[] = [];
-    const srcKeyLabelLookUp: KeyLabelLookup = {};
-    
-    configSettings.forEach((config: SetConfigurationSettingParam<string | FeatureFlagValue | SecretReferenceValue>) => {
-      if (!srcKeyLabelLookUp[config.key]) {
-        srcKeyLabelLookUp[config.key] = {};
-      }
-      srcKeyLabelLookUp[config.key][config.label || ""] = true;
-    });
 
-    configurationSettingToAdd.push(...configSettings);
+    // Build O(1) lookup structures keyed by "key\0label" composite.
+    const srcMap = new Map<string, SetConfigurationSettingParam<string | FeatureFlagValue | SecretReferenceValue>>();
+    const toAddKeys = new Set<string>();
+    for (const config of configSettings) {
+      const composite = `${config.key}\u0000${config.label ?? ""}`;
+      srcMap.set(composite, config);
+      toAddKeys.add(composite);
+    }
 
-    for await (const existing of this.configurationClient.listConfigurationSettings({...configSettingsSource.FilterOptions, ...customHeadersOption})) {
-      const isKeyLabelPresent: boolean = srcKeyLabelLookUp[existing.key] && srcKeyLabelLookUp[existing.key][existing.label || ""];
-      
+    const targetSettings = await targetPromise;
+
+    for (const existing of targetSettings) {
+      const composite = `${existing.key}\u0000${existing.label ?? ""}`;
+      const isKeyLabelPresent: boolean = srcMap.has(composite);
+
       if (strict && !isKeyLabelPresent) {
         configurationChanges.push({
           changeType: ChangeType.Delete,
@@ -154,11 +170,11 @@ export class AppConfigurationImporter {
         });
       }
 
-      const incoming = configSettings.find(configSetting => configSetting.key == existing.key && configSetting.label === existing.label);
+      const incoming = srcMap.get(composite);
 
       if (incoming) {
         // Remove from add list since it already exists
-        configurationSettingToAdd.splice(configurationSettingToAdd.indexOf(incoming), 1);
+        toAddKeys.delete(composite);
 
         if (!isConfigSettingEqual(incoming, existing)) {
           configurationChanges.push({
@@ -177,11 +193,11 @@ export class AppConfigurationImporter {
       }
     }
 
-    for (const setting of configurationSettingToAdd) {
+    for (const composite of toAddKeys) {
       configurationChanges.push({
         changeType: ChangeType.Create,
         currentValue: null,
-        newValue: setting
+        newValue: srcMap.get(composite)!
       });
     }
 

--- a/libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts
+++ b/libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts
@@ -121,38 +121,14 @@ export class AppConfigurationImporter {
       };
     }
 
-    // Start fetching source settings and (in parallel) prime the target listing.
-    // The source must be fully loaded to build the lookup map, but the target side is
-    // consumed as a stream below so we never hold the entire store in memory.
-    const isChangesSource = configSettingsSource instanceof ConfigurationChangesSource;
-    const abortController = new AbortController();
-    const sourcePromise = configSettingsSource.GetConfigurationSettings();
-    // Abort the in-flight target pagination if the source fails.
-    sourcePromise.catch(() => abortController.abort());
-
-    const targetIterable = isChangesSource
-      ? null
-      : this.configurationClient.listConfigurationSettings({
-        ...configSettingsSource.FilterOptions,
-        ...customHeadersOption,
-        abortSignal: abortController.signal
-      });
-
-    let configSettingsResult;
-    try {
-      configSettingsResult = await sourcePromise;
-    } catch (e) {
-      abortController.abort();
-      throw e;
-    }
+    const configSettingsResult = await configSettingsSource.GetConfigurationSettings();
 
     // If the source returns ConfigurationChanges (e.g., ConfigurationChangesSource), 
     // return them directly without further processing since changes are already calculated
     if (this.isConfigurationChanges(configSettingsResult)) {
-      abortController.abort();
       return configSettingsResult as Array<ConfigurationSettingChange>;
     }
-  
+
     const configSettings = configSettingsResult as Array<SetConfigurationSettingParam<string | FeatureFlagValue | SecretReferenceValue>>;
     const configurationChanges: Array<ConfigurationSettingChange> = [];
 
@@ -166,37 +142,38 @@ export class AppConfigurationImporter {
     }
 
     // Stream target settings so we don't hold the entire remote store in memory.
-    if (targetIterable) {
-      for await (const existing of targetIterable) {
-        const composite = `${existing.key}\u0000${existing.label ?? ""}`;
-        const incoming = srcMap.get(composite);
+    for await (const existing of this.configurationClient.listConfigurationSettings({
+      ...configSettingsSource.FilterOptions,
+      ...customHeadersOption
+    })) {
+      const composite = `${existing.key}\u0000${existing.label ?? ""}`;
+      const incoming = srcMap.get(composite);
 
-        if (strict && !incoming) {
+      if (strict && !incoming) {
+        configurationChanges.push({
+          changeType: ChangeType.Delete,
+          currentValue: existing,
+          newValue: null
+        });
+      }
+
+      if (incoming) {
+        // Remove from add list since it already exists
+        toAddKeys.delete(composite);
+
+        if (!isConfigSettingEqual(incoming, existing)) {
           configurationChanges.push({
-            changeType: ChangeType.Delete,
+            changeType: ChangeType.Update,
             currentValue: existing,
-            newValue: null
+            newValue: incoming
           });
         }
-
-        if (incoming) {
-          // Remove from add list since it already exists
-          toAddKeys.delete(composite);
-
-          if (!isConfigSettingEqual(incoming, existing)) {
-            configurationChanges.push({
-              changeType: ChangeType.Update,
-              currentValue: existing,
-              newValue: incoming
-            });
-          } 
-          else if (importMode === ImportMode.All) {
-            configurationChanges.push({
-              changeType: ChangeType.None,
-              currentValue: existing,
-              newValue: incoming
-            });
-          }
+        else if (importMode === ImportMode.All) {
+          configurationChanges.push({
+            changeType: ChangeType.None,
+            currentValue: existing,
+            newValue: incoming
+          });
         }
       }
     }

--- a/libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts
+++ b/libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts
@@ -121,26 +121,35 @@ export class AppConfigurationImporter {
       };
     }
 
-    // Fetch source settings and target store settings in parallel.
-    // For ConfigurationChangesSource the target listing is skipped (changes are pre-calculated and
-    // FilterOptions are not supported on that source type).
+    // Start fetching source settings and (in parallel) prime the target listing.
+    // The source must be fully loaded to build the lookup map, but the target side is
+    // consumed as a stream below so we never hold the entire store in memory.
     const isChangesSource = configSettingsSource instanceof ConfigurationChangesSource;
+    const abortController = new AbortController();
     const sourcePromise = configSettingsSource.GetConfigurationSettings();
-    const targetPromise: Promise<ConfigurationSetting[]> = isChangesSource
-      ? Promise.resolve([])
-      : (async () => {
-        const items: ConfigurationSetting[] = [];
-        for await (const existing of this.configurationClient.listConfigurationSettings({...configSettingsSource.FilterOptions, ...customHeadersOption})) {
-          items.push(existing);
-        }
-        return items;
-      })();
+    // Abort the in-flight target pagination if the source fails.
+    sourcePromise.catch(() => abortController.abort());
 
-    const configSettingsResult = await sourcePromise;
+    const targetIterable = isChangesSource
+      ? null
+      : this.configurationClient.listConfigurationSettings({
+        ...configSettingsSource.FilterOptions,
+        ...customHeadersOption,
+        abortSignal: abortController.signal
+      });
+
+    let configSettingsResult;
+    try {
+      configSettingsResult = await sourcePromise;
+    } catch (e) {
+      abortController.abort();
+      throw e;
+    }
 
     // If the source returns ConfigurationChanges (e.g., ConfigurationChangesSource), 
     // return them directly without further processing since changes are already calculated
     if (this.isConfigurationChanges(configSettingsResult)) {
+      abortController.abort();
       return configSettingsResult as Array<ConfigurationSettingChange>;
     }
   
@@ -156,39 +165,38 @@ export class AppConfigurationImporter {
       toAddKeys.add(composite);
     }
 
-    const targetSettings = await targetPromise;
+    // Stream target settings so we don't hold the entire remote store in memory.
+    if (targetIterable) {
+      for await (const existing of targetIterable) {
+        const composite = `${existing.key}\u0000${existing.label ?? ""}`;
+        const incoming = srcMap.get(composite);
 
-    for (const existing of targetSettings) {
-      const composite = `${existing.key}\u0000${existing.label ?? ""}`;
-      const isKeyLabelPresent: boolean = srcMap.has(composite);
-
-      if (strict && !isKeyLabelPresent) {
-        configurationChanges.push({
-          changeType: ChangeType.Delete,
-          currentValue: existing,
-          newValue: null
-        });
-      }
-
-      const incoming = srcMap.get(composite);
-
-      if (incoming) {
-        // Remove from add list since it already exists
-        toAddKeys.delete(composite);
-
-        if (!isConfigSettingEqual(incoming, existing)) {
+        if (strict && !incoming) {
           configurationChanges.push({
-            changeType: ChangeType.Update,
+            changeType: ChangeType.Delete,
             currentValue: existing,
-            newValue: incoming
+            newValue: null
           });
-        } 
-        else if (importMode === ImportMode.All) {
-          configurationChanges.push({
-            changeType: ChangeType.None,
-            currentValue: existing,
-            newValue: incoming
-          });
+        }
+
+        if (incoming) {
+          // Remove from add list since it already exists
+          toAddKeys.delete(composite);
+
+          if (!isConfigSettingEqual(incoming, existing)) {
+            configurationChanges.push({
+              changeType: ChangeType.Update,
+              currentValue: existing,
+              newValue: incoming
+            });
+          } 
+          else if (importMode === ImportMode.All) {
+            configurationChanges.push({
+              changeType: ChangeType.None,
+              currentValue: existing,
+              newValue: incoming
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Improves the performance of `AppConfigurationImporter.GetConfigurationChanges` through two internal changes. Public API surface, return value shape, and observable behavior are unchanged for all existing source types and scenarios.

## Motivation

Currently, for example, when importing from configuration file which has 2000 KVs and target store has 3 KVs, total time taken is 1.36s nearly. However, when importing from configuration file which has 2000 KVs and target store also has 2000 KVs, it took 12s approximately. There is room for optimization.

The following are the reasons why running GetConfigurationChanges is currently slow:
1. The internal diff used `Array.find` + `Array.splice` on the source array for every target item, producing **O(N × M)** complexity that degrades quickly when both stores grow.

## Changes

All changes are internal to `GetConfigurationChanges` in `libraries/azure-app-configuration-importer/src/appConfigurationImporter.ts`.

### 1. O(N + M) diff using `Map` and `Set`
- Replaced the nested-object lookup (`srcKeyLabelLookUp[key][label]`) with `srcMap: Map<"key\u0000label", incoming>`.
- Replaced `configurationSettingToAdd` (array + `Array.find` + `splice(indexOf(...))`) with `toAddKeys: Set<"key\u0000label">`.
- The composite key uses the NUL character (`\u0000`) as the separator since it cannot appear in App Configuration keys or labels, guaranteeing uniqueness.

## Version bump

Bumps `libraries/azure-app-configuration-importer` from `3.0.0-preview` to `3.0.1-preview` (next preview iteration; no public API additions).
